### PR TITLE
Fix Linux build

### DIFF
--- a/compileOgg.sh
+++ b/compileOgg.sh
@@ -22,5 +22,5 @@ emmake make install
 # compile wrapper
 cd ..
 mkdir -p build
-emcc -O3 -s RESERVED_FUNCTION_POINTERS=50 -s EXPORTED_FUNCTIONS="['_AVOggInit', '_AVOggRead', '_AVOggDestroy']" -I libogg/include -Llibogg/build/lib -logg src/ogg.c -o build/libogg.js
+emcc -O3 --memory-init-file 0 -s RESERVED_FUNCTION_POINTERS=50 -s EXPORTED_FUNCTIONS="['_AVOggInit', '_AVOggRead', '_AVOggDestroy']" -I libogg/include -Llibogg/build/lib -logg src/ogg.c -o build/libogg.js
 echo "module.exports = Module" >> build/libogg.js

--- a/compileOgg.sh
+++ b/compileOgg.sh
@@ -8,11 +8,11 @@ if [ ! -f configure ]; then
   
   # -O20 and -04 cause problems
   # see https://github.com/kripken/emscripten/issues/264
-  sed -i '' 's/-O20/-O2/g' configure
-  sed -i '' 's/-O4/-O2/g' configure
+  perl -pi -e s,-O20,-O2,g configure
+  perl -pi -e s,-O4,-O2,g configure
   
   # finally, run configuration script
-  emconfigure ./configure --prefix="`pwd`" --disable-static
+  emconfigure ./configure --prefix="`pwd`/build" --disable-static
 fi
 
 # compile libogg
@@ -22,5 +22,5 @@ emmake make install
 # compile wrapper
 cd ..
 mkdir -p build
-emcc -O3 -s RESERVED_FUNCTION_POINTERS=50 -s EXPORTED_FUNCTIONS="['_AVOggInit', '_AVOggRead', '_AVOggDestroy']" -I libogg/include -Llibogg/lib -logg src/ogg.c -o build/libogg.js
+emcc -O3 -s RESERVED_FUNCTION_POINTERS=50 -s EXPORTED_FUNCTIONS="['_AVOggInit', '_AVOggRead', '_AVOggDestroy']" -I libogg/include -Llibogg/build/lib -logg src/ogg.c -o build/libogg.js
 echo "module.exports = Module" >> build/libogg.js

--- a/src/ogg.c
+++ b/src/ogg.c
@@ -6,35 +6,38 @@
 typedef void (*AVCallback)(unsigned char *, int);
 
 typedef struct {
-  ogg_sync_state state;
+  ogg_sync_state *state;
   ogg_page page;
-  ogg_stream_state stream;
+  ogg_stream_state *stream;
   ogg_packet packet;
 } AVOgg;
 
 AVOgg *AVOggInit() {
   AVOgg *ogg = calloc(1, sizeof(AVOgg));
-  assert(!ogg_sync_init(&ogg->state));
+  ogg->state = calloc(1, sizeof(ogg_sync_state));
+  ogg->stream = calloc(1, sizeof(ogg_stream_state));
+  assert(!ogg_sync_init(ogg->state));
+  assert(ogg_sync_pageout(ogg->state, &ogg->page) != 1);
   return ogg;
 }
 
 int AVOggRead(AVOgg *ogg, char *buffer, int buflen, AVCallback callback) {
   // write buffer into ogg stream
-  char *oggBuf = ogg_sync_buffer(&ogg->state, buflen);
+  char *oggBuf = ogg_sync_buffer(ogg->state, buflen);
   memcpy(oggBuf, buffer, buflen);
-  assert(!ogg_sync_wrote(&ogg->state, buflen));
+  assert(!ogg_sync_wrote(ogg->state, buflen));
   
   // read ogg pages
-  while (ogg_sync_pageout(&ogg->state, &ogg->page) == 1) {
+  while (ogg_sync_pageout(ogg->state, &ogg->page) == 1) {
     int serial = ogg_page_serialno(&ogg->page);
   
     if (ogg_page_bos(&ogg->page))
-      assert(!ogg_stream_init(&ogg->stream, serial));
+      assert(!ogg_stream_init(ogg->stream, serial));
   
-    assert(!ogg_stream_pagein(&ogg->stream, &ogg->page));
+    assert(!ogg_stream_pagein(ogg->stream, &ogg->page));
   
     // read packets
-    while (ogg_stream_packetout(&ogg->stream, &ogg->packet) == 1)
+    while (ogg_stream_packetout(ogg->stream, &ogg->packet) == 1)
       callback(ogg->packet.packet, ogg->packet.bytes);
   }
     
@@ -42,6 +45,7 @@ int AVOggRead(AVOgg *ogg, char *buffer, int buflen, AVCallback callback) {
 }
 
 void AVOggDestroy(AVOgg *ogg) {
-  ogg_sync_destroy(&ogg->state);
+  ogg_sync_destroy(ogg->state);
+  ogg_stream_destroy(ogg->stream);
   free(ogg);
 }

--- a/src/ogg.c
+++ b/src/ogg.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <ogg/ogg.h>
 
-typedef void (*AVCallback)(unsigned char *, int);
+typedef void (*AVCallback)(unsigned char *, int, long, long);
 
 typedef struct {
   ogg_sync_state *state;
@@ -38,7 +38,7 @@ int AVOggRead(AVOgg *ogg, char *buffer, int buflen, AVCallback callback) {
   
     // read packets
     while (ogg_stream_packetout(ogg->stream, &ogg->packet) == 1)
-      callback(ogg->packet.packet, ogg->packet.bytes);
+      callback(ogg->packet.packet, ogg->packet.bytes, ogg->packet.e_o_s, ogg->packet.granulepos);
   }
     
   return 0;

--- a/src/ogg.js
+++ b/src/ogg.js
@@ -22,7 +22,7 @@ var OggDemuxer = AV.Demuxer.extend(function() {
     // copy the stream in case we override it, e.g. flac
     this._stream = this.stream;
     
-    this.callback = Ogg.Runtime.addFunction(function(packet, bytes) {
+    this.callback = Ogg.Runtime.addFunction(function(packet, bytes, streamEnd, granulePos) {
       var data = new Uint8Array(Ogg.HEAPU8.subarray(packet, packet + bytes));      
       
       // find plugin for codec
@@ -47,7 +47,7 @@ var OggDemuxer = AV.Demuxer.extend(function() {
       if (!doneHeaders)
         doneHeaders = plugin.readHeaders.call(self, data);
       else
-        plugin.readPacket.call(self, data);
+        plugin.readPacket.call(self, data, streamEnd, granulePos);
     });
   };
   

--- a/src/ogg.js
+++ b/src/ogg.js
@@ -52,10 +52,11 @@ var OggDemuxer = AV.Demuxer.extend(function() {
   };
   
   this.prototype.readChunk = function() {
-    while (this._stream.available(BUFFER_SIZE)) {
-      Ogg.HEAPU8.set(this._stream.readBuffer(BUFFER_SIZE).data, this.buf);
-      Ogg._AVOggRead(this.ogg, this.buf, BUFFER_SIZE, this.callback);
-    }
+    do {
+      var toRead = BUFFER_SIZE <= this._stream.list.availableBytes ? BUFFER_SIZE : this._stream.list.availableBytes;
+      Ogg.HEAPU8.set(this._stream.readBuffer(toRead).data, this.buf);
+      Ogg._AVOggRead(this.ogg, this.buf, toRead, this.callback);
+    } while (this._stream.available(BUFFER_SIZE))
   };
   
   this.prototype.destroy = function() {

--- a/src/ogg.js
+++ b/src/ogg.js
@@ -52,11 +52,12 @@ var OggDemuxer = AV.Demuxer.extend(function() {
   };
   
   this.prototype.readChunk = function() {
-    do {
-      var toRead = BUFFER_SIZE <= this._stream.list.availableBytes ? BUFFER_SIZE : this._stream.list.availableBytes;
+    var avail;
+    while((avail = this._stream.remainingBytes()) > 0) {
+      var toRead = BUFFER_SIZE <= avail ? BUFFER_SIZE : avail;
       Ogg.HEAPU8.set(this._stream.readBuffer(toRead).data, this.buf);
       Ogg._AVOggRead(this.ogg, this.buf, toRead, this.callback);
-    } while (this._stream.available(BUFFER_SIZE))
+    }
   };
   
   this.prototype.destroy = function() {


### PR DESCRIPTION
Two things in this commit:

As I learnt in #8, Linux and BSD (OSX) sed syntax for in place edits with -i are incompatible. Perl is as widely available as sed and has consistent syntax, so use that instead. If you'd rather not use perl, there are cross platform sed arguments that work, but must create a backup file when using -i.

Secondly, when building I received:  
`/usr/bin/install: ‘config_types.h’ and ‘ogg.js/libogg/include/ogg/config_types.h’ are the same file`

This is due to the install directory being the same as the source directory. Moving the build into a `build` folder fixes this.

If you're happy with this pull request, I'll go do the rest of the emscripten Aurora plugins as well.
