### PR TITLE
Fix double free and memory leaks

### DIFF
--- a/src/ogg.c
+++ b/src/ogg.c
@@ -6,35 +6,38 @@
 typedef void (*AVCallback)(unsigned char *, int);
 
 typedef struct {
-  ogg_sync_state state;
+  ogg_sync_state *state;
   ogg_page page;
-  ogg_stream_state stream;
+  ogg_stream_state *stream;
   ogg_packet packet;
 } AVOgg;
 
 AVOgg *AVOggInit() {
   AVOgg *ogg = calloc(1, sizeof(AVOgg));
-  assert(!ogg_sync_init(&ogg->state));
+  ogg->state = calloc(1, sizeof(ogg_sync_state));
+  ogg->stream = calloc(1, sizeof(ogg_stream_state));
+  assert(!ogg_sync_init(ogg->state));
+  assert(ogg_sync_pageout(ogg->state, &ogg->page) != 1);
   return ogg;
 }
 
 int AVOggRead(AVOgg *ogg, char *buffer, int buflen, AVCallback callback) {
   // write buffer into ogg stream
-  char *oggBuf = ogg_sync_buffer(&ogg->state, buflen);
+  char *oggBuf = ogg_sync_buffer(ogg->state, buflen);
   memcpy(oggBuf, buffer, buflen);
-  assert(!ogg_sync_wrote(&ogg->state, buflen));
+  assert(!ogg_sync_wrote(ogg->state, buflen));
   
   // read ogg pages
-  while (ogg_sync_pageout(&ogg->state, &ogg->page) == 1) {
+  while (ogg_sync_pageout(ogg->state, &ogg->page) == 1) {
     int serial = ogg_page_serialno(&ogg->page);
   
     if (ogg_page_bos(&ogg->page))
-      assert(!ogg_stream_init(&ogg->stream, serial));
+      assert(!ogg_stream_init(ogg->stream, serial));
   
-    assert(!ogg_stream_pagein(&ogg->stream, &ogg->page));
+    assert(!ogg_stream_pagein(ogg->stream, &ogg->page));
   
     // read packets
-    while (ogg_stream_packetout(&ogg->stream, &ogg->packet) == 1)
+    while (ogg_stream_packetout(ogg->stream, &ogg->packet) == 1)
       callback(ogg->packet.packet, ogg->packet.bytes);
   }
     
@@ -42,6 +45,7 @@ int AVOggRead(AVOgg *ogg, char *buffer, int buflen, AVCallback callback) {
 }
 
 void AVOggDestroy(AVOgg *ogg) {
-  ogg_sync_destroy(&ogg->state);
+  ogg_sync_destroy(ogg->state);
+  ogg_stream_destroy(ogg->stream);
   free(ogg);
 }


### PR DESCRIPTION
Fixes #9.

`ogg_sync_destroy` frees `ogg->state`, which is then freed again by `free(ogg)`. By allocating this separately and letting libogg free it this is avoided.

`ogg_stream_init` allocates 3 buffers, which are not properly freed. By separately allocating `ogg->stream` and calling `ogg_stream_destroy`, these are properly freed. Saves ~26kb of lost memory.

Finally, libogg recommends `ogg_sync_pageout` be called before `ogg_sync_buffer` to initialise some buffers. Added a call to it inside `AVOggInit` to follow this recommendation.
